### PR TITLE
E90ex issue patch

### DIFF
--- a/libraries/AP_Mount/AP_Mount_Mavlink.cpp
+++ b/libraries/AP_Mount/AP_Mount_Mavlink.cpp
@@ -263,7 +263,7 @@ void AP_Mount_Mavlink::find_gimbal()
         return;
     }
 
-    bool findgimbal = GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GENERIC, _sysid, _compid, _chan);
+    bool findgimbal = GCS_MAVLINK::find_by_mavtype(MAV_TYPE_GIMBAL, _sysid, _compid, _chan);
     findgimbal &= (_compid == 154);
     if (findgimbal) {
         _initialised = true;

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -274,7 +274,7 @@ void MAVLink_routing::learn_route(mavlink_channel_t in_channel, const mavlink_me
 #if false   // original code in APM
                 routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
 #else
-                if (msg.compid != 154 ) {
+                if (msg.compid != MAV_COMP_ID_GIMBAL ) {
                     routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
                 }
                 else { // If come from a gimbal, set mavtype as GIMBAL type.

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -293,7 +293,7 @@ void MAVLink_routing::learn_route(mavlink_channel_t in_channel, const mavlink_me
 #if false   // original code in APM
                 routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
 #else
-                if (msg.compid != 154 ) {
+                if (msg.compid != MAV_COMP_ID_GIMBAL ) {
                     routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
                 }
                 else { // If come from a gimbal, set mavtype as GIMBAL type.

--- a/libraries/GCS_MAVLink/MAVLink_routing.cpp
+++ b/libraries/GCS_MAVLink/MAVLink_routing.cpp
@@ -271,7 +271,16 @@ void MAVLink_routing::learn_route(mavlink_channel_t in_channel, const mavlink_me
             routes[i].compid == msg.compid &&
             routes[i].channel == in_channel) {
             if (routes[i].mavtype == 0 && msg.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
+#if false   // original code in APM
                 routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
+#else
+                if (msg.compid != 154 ) {
+                    routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
+                }
+                else { // If come from a gimbal, set mavtype as GIMBAL type.
+                    routes[i].mavtype = MAV_TYPE_GIMBAL;
+                }
+#endif                
             }
             break;
         }
@@ -281,7 +290,16 @@ void MAVLink_routing::learn_route(mavlink_channel_t in_channel, const mavlink_me
         routes[i].compid = msg.compid;
         routes[i].channel = in_channel;
         if (msg.msgid == MAVLINK_MSG_ID_HEARTBEAT) {
-            routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
+#if false   // original code in APM
+                routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
+#else
+                if (msg.compid != 154 ) {
+                    routes[i].mavtype = mavlink_msg_heartbeat_get_type(&msg);
+                }
+                else { // If come from a gimbal, set mavtype as GIMBAL type.
+                    routes[i].mavtype = MAV_TYPE_GIMBAL;
+                }
+#endif                
         }
         num_routes++;
 #if ROUTING_DEBUG


### PR DESCRIPTION
- learn gimbal's mav_message as MAV_TYPE_GIMBAL in MAVlink_routing.
- when finding a gimbal, use MAV_TYPE_GIMBAL as type in AP_Mount_Mavlink.
